### PR TITLE
feat: update browserManager

### DIFF
--- a/examples/sdk_test/sdk_test.js
+++ b/examples/sdk_test/sdk_test.js
@@ -1,7 +1,7 @@
 import { NstBrowser } from 'nstbrowser-sdk-node';
 
-const nst = new NstBrowser('acd77f76-6564-46d4-82f5-a0ac770f281c', {
-  apiAddress: 'http://localhost:8848/api/v1',
+const nst = new NstBrowser('your_api_key', {
+  apiAddress: 'http://localhost:8848/api/agent',
 });
 
 const {
@@ -11,7 +11,7 @@ const {
   stop,
   stopSome,
   stopAll,
-  getRunningBrowserAll,
+  getRunningBrowser,
 } = nst.browserManager();
 
 // force start browser
@@ -33,6 +33,6 @@ stopSome(['fd08ec59-071f-4f48-b225-b5dad5f9fda8', 'd8b7aeb2-0dd2-4169-938a-80ab0
 stopAll();
 
 // get all running browsers
-getRunningBrowserAll().then(res => {
+getRunningBrowser().then(res => {
   console.log('all running browsers info: ', res.data);
 });

--- a/src/controller/browserManager/browserManager.controller.ts
+++ b/src/controller/browserManager/browserManager.controller.ts
@@ -6,6 +6,7 @@ import {
   stopSomeService,
   stopAllService,
   getRunningBrowserAllService,
+  getRunningBrowserService,
   getRemoteWebSocketDebuggingURLService,
   getProfilesStatusService,
 } from '@/service/browserManager/browserManager.service.ts';
@@ -55,6 +56,12 @@ function browserManager(config: SubClassConfig): BrowserManager {
     return data;
   }
 
+  async function getRunningBrowser() {
+    const data = await getRunningBrowserService(config);
+
+    return data;
+  }
+
   async function getRemoteDebuggingAddress(profileId: string) {
     const data = await getRemoteWebSocketDebuggingURLService(config, profileId);
 
@@ -75,6 +82,7 @@ function browserManager(config: SubClassConfig): BrowserManager {
     stop,
     stopSome,
     stopAll,
+    getRunningBrowser,
     getRunningBrowserAll,
     getRemoteDebuggingAddress,
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ class NstBrowser {
 
   protected apiKey: string = '';
   protected timeout: number = 0;
-  protected apiAddress: string = 'http://localhost:8848/api/v1';
+  protected apiAddress: string = 'http://localhost:8848/api/agent';
 
   constructor(key: string, options?: NstBrowserOption) {
     if (NstBrowser.instance) {

--- a/src/service/browserManager/browserManager.service.ts
+++ b/src/service/browserManager/browserManager.service.ts
@@ -88,6 +88,20 @@ export async function getRunningBrowserAllService(config: SubClassConfig) {
   return data;
 }
 
+export async function getRunningBrowserService(config: SubClassConfig) {
+  const data = await request<NstResponse<RunningBrowserInfo[]>>({
+    url: config.baseUrl + '/browser/running',
+    method: 'get',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+
+  return data;
+}
+
+
 export async function getRemoteWebSocketDebuggingURLService(config: SubClassConfig, profileId: string) {
   const url = config.baseUrl + `/browser/devtool/${profileId}`;
   const data = await request<NstResponse<string>>({

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,10 @@ export type KernelType = 0 | 1;
 
 export type PlatForm = 0 | 1 | 2 | 3 | 4;
 
+export type KernelEnum = 'chromium';
+
+export type PlatformEnum = 'linux' | 'mac' | 'windows';
+
 export type KernelInfo = {
   name: string;
   kernelType: KernelType;
@@ -101,10 +105,17 @@ export interface BrowserProfileStatus {
 
 export interface CreateProfileParam {
   groupId?: string;
-  kernel: KernelType;
+  kernel: KernelEnum;
   kernelMilestone: string;
   name: string;
-  platform: PlatForm;
+  platform: PlatformEnum;
+  args?: Record<string, string>;
+  groupName?: string;
+  fingerprint?: Record<string, any>;
+  note?: string;
+  proxy?: string;
+  proxyGroupName?: string;
+  startupUrls?: string[];
 }
 
 export interface CreateProfileResponse {
@@ -220,7 +231,9 @@ export interface BrowserManager {
   stop: (profileId: string) => Promise<NstResponse<any>>;
   stopSome: (profileIds: string[]) => Promise<NstResponse<any>>;
   stopAll: () => Promise<NstResponse<any>>;
+  /** @deprecated please use `getRunningBrowser` instead */
   getRunningBrowserAll: () => Promise<NstResponse<RunningBrowserInfo[]>>;
+  getRunningBrowser: () => Promise<NstResponse<RunningBrowserInfo[]>>;
   getRemoteDebuggingAddress: (
     profileId: string,
   ) => Promise<NstResponse<string>>;


### PR DESCRIPTION
## Overview

This PR updates the `browserManager` module with the following changes:

1. **API Endpoint Update**
   - Changed API endpoint from `/api/v1` to `/api/agent`.

2. **Method Replacement**
   - Added `getRunningBrowser` method to replace the deprecated `getRunningBrowserAll`.

3. **Type Definitions**
   - Updated `Kernel` and `Platform` types to use enums for better type safety.
