### PR TITLE
feat: add support for api-v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env
+.yalc
+yalc.lock
+

--- a/README-v1.md
+++ b/README-v1.md
@@ -1,0 +1,447 @@
+# NST BROWSER NODE SDK
+Nst browser node sdk
+
+## Installing
+Using npm:
+
+```bash
+$ npm install nstbrowser-sdk-node
+```
+
+Using pnpm:
+
+```bash
+$ pnpm install nstbrowser-sdk-node
+```
+
+Using yarn:
+
+```bash
+$ yarn add nstbrowser-sdk-node
+```
+
+## How To Use
+
+javascript:
+
+```js
+import { NstBrowser } from 'nstbrowser-sdk-node';
+
+const nst = new NstBrowser('your api key', {
+  timeout: 60000,
+  apiAddress: 'http://localhost:8848/api/agent'
+});
+const { getLatestVersion } = nst.agentManager();
+getLatestVersion();
+```
+
+typescript:
+
+```ts
+import { NstBrowser, NstBrowserTypes } from 'nstbrowser-sdk-node';
+
+const nst: NstBrowserTypes = new NstBrowser('your api key', {
+  timeout: 60000,
+  apiAddress: 'http://localhost:8848/api/agent'
+});
+const { getLatestVersion } = nst.agentManager();
+getLatestVersion();
+```
+
+Browserless:
+
+```js
+import { Browserless } from 'nstbrowser-sdk-node';
+
+const browserless = new Browserless({
+  apiKey: 'your api key',
+  proxy: 'your proxy', // required
+})
+
+browserless.load('https://nstbrowser.io').then(text => {
+  
+})
+```
+
+## NstBrowser Node Sdk Response Schema:
+
+```js
+{
+  // `data` is the response
+  "data": {},
+    
+  // `code` is the HTTP status code
+  "code": 200,
+  
+  // `err` is the request's status
+  "err": false,
+  
+  "msg": "success"
+}
+```
+
+
+
+## BrowserManager
+
+### forceStart
+
+force start the browser by profileId
+```ts
+const { forceStart } = nst.browserManager();
+forceStart(profileId: string);
+```
+
+### start
+
+start the browser by profileId
+
+```ts
+const { start } = nst.browserManager();
+start(profileId: string);
+```
+
+### startSome
+
+batch start browser by profileIds
+
+```ts
+const { startSome } = nst.browserManager();
+startSome(profileIds: string[]);
+```
+
+### stop
+
+stop the browser by profileId
+
+```ts
+const { stop } = nst.browserManager();
+stop(profileId: string);
+```
+
+### stopSome
+
+batch stop browser by profileIds
+
+```ts
+const { stopSome } = nst.browserManager();
+stopSome(profileIds: string[]);
+```
+
+### stopAll
+
+stop all running browser
+
+```ts
+const { stopAll } = nst.browserManager();
+stopAll();
+```
+
+### getRunningBrowserAll
+
+get all running browser's info
+
+```ts
+const { getRunningBrowserAll } = nst.browserManager();
+getRunningBrowserAll();
+```
+
+response data:
+
+```js
+[
+  {
+    profileId: "string",
+    name: "string",
+    version: "string",
+    kernelType: "string", // nstchrome | nstfirefox
+    running: "boolean",
+    userDirPath: "string"
+  }
+]
+```
+
+### getRemoteDebuggingAddress
+
+get browser remote web socket debugging url
+
+```ts
+const { getRemoteDebuggingAddress } = nst.browserManager();
+getRemoteDebuggingAddress(profileId: string);
+```
+
+### getProfilesStatus
+
+get all profiles status
+```ts
+const { getProfilesStatus } = nst.browserManager();
+getProfilesStatus();
+```
+
+
+
+## ProfileManager
+
+### createProfile
+
+create profile
+
+[Detail docs](https://apidocs.nstbrowser.io/api-5496096)
+
+```ts
+const { createProfile } = nst.profileManager();
+createProfile({
+  "kernel": "chromium",
+  "kernelMilestone": "120",
+  "name": "Profile",
+  "platform": "windows"
+});
+```
+
+response data:
+```js
+{
+  "_id": "string",
+  "createdAt": "string",
+  "fingerprintId": "string",
+  "groupId": "string",
+  "kernel": 0,
+  "kernelMilestone": "string",
+  "kernelVersion": "string",
+  "name": "string",
+  "note": "string",
+  "platform": 0,
+  "platformVersion": "string",
+  "profileId": "string",
+  "saveLocal": true,
+  "status": 0,
+  "tags": [
+    "string"
+  ],
+  "teamId": "string",
+  "uaFullVersion": "string",
+  "updatedAt": "string",
+  "userId": "string"
+}
+```
+
+### deleteProfile
+
+delete profile by profileId
+
+```ts
+const { deleteProfile } = nst.profileManager();
+deleteProfile(profileId: string);
+```
+
+### profiles
+
+list profiles
+
+```ts
+const { profiles } = nst.profileManager();
+profiles({
+  	page: 1,
+	  pageSize: 10,
+  	s: '',
+  	groupId: ''
+});
+```
+
+response data:
+
+```js
+"data": {
+    "docs": [
+        {
+            "fingerprintId": "string",
+            "groupId": "string",
+            "kernel": 0,
+            "kernelMilestone": "string",
+            "kernelVersion": "string",
+            "name": "string",
+            "note": "string",
+            "platform": 0,
+            "platformVersion": "string",
+            "profileId": "string",
+            "proxyConfig": {
+                "checker": "string",
+                "host": "string",
+                "password": "string",
+                "port": "string",
+                "protocol": "string",
+                "proxySetting": "string",
+                "proxyType": "string",
+                "url": "string",
+                "username": "string"
+            },
+            "tags": [
+                "string"
+            ],
+            "teamId": "string",
+            "uaFullVersion": "string",
+            "userId": "string"
+        }
+    ],
+    "hasNextPage": true,
+    "hasPrevPage": true,
+    "limit": 0,
+    "nextPage": 0,
+    "offset": 0,
+    "page": 0,
+    "pagingCounter": 0,
+    "prevPage": 0,
+    "totalDocs": 0,
+    "totalPages": 0
+}
+```
+
+### batchUpdateProxy
+
+batch update proxy for profiles, if proxy url is empty,you should set value to: protocol、host and port, otherwise set proxy url just fine.
+
+```ts
+const { batchUpdateProxy } = nst.profileManager();
+batchUpdateProxy({
+  "profileIds": ["string"],
+  "proxyConfig": {
+    "checker": "string",
+    "host": "string",
+    "password": "string",
+    "port": "string",
+    "protocol": "string",
+    "proxySetting": "string",
+    "proxyType": "string",
+    "url": "string",
+    "username": "string"
+  }
+});
+```
+
+### getProfileTags
+get all profile tags
+
+```ts
+const { getProfileTags } = nst.profileManager();
+getProfileTags();
+```
+
+response data:
+
+```js
+[
+  {
+    color: "string",
+    name: "string",
+  }
+]
+```
+
+### batchUpdateProfileTags
+batch update profile tags
+
+```ts
+const { batchUpdateProfileTags } = nst.profileManager();
+
+batchUpdateProfileTags({
+  "profileIds": string[],
+  "tags": {
+    "color": string;
+    "name": string;
+  }[]
+});
+```
+
+### batchCreateProfileTags
+batch create profile tags
+
+```ts
+const { batchCreateProfileTags } = nst.profileManager();
+
+batchCreateProfileTags({
+  "profileIds": string[],
+  "tags": {
+    "color": string;
+    "name": string;
+  }[]
+});
+```
+
+### batchClearProfileTags
+
+batch clear profile tags
+
+```ts
+const { batchClearProfileTags } = nst.profileManager();
+
+batchClearProfileTags({
+  "profileIds": ["string"]
+});
+```
+
+### clearCookies
+
+clear local cookies by profileId
+
+```ts
+const { clearCookies } = nst.profileManager();
+clearCookies("profileId")
+```
+
+### clearProfileCache
+
+clear user profile dir.
+
+```ts
+const { clearProfileCache } = nst.profileManager();
+clearProfileCache("profileId")
+```
+
+### batchClearProfileCache
+
+batch clear user profile dir.
+
+```ts
+const { batchClearProfileCache } = nst.profileManager();
+batchClearProfileCache(["profileId"])
+```
+
+## Devtool
+
+### launchNewBrowser
+
+launch new browser
+[Detail docs](https://apidocs.nstbrowser.io/api-5418530)
+```ts
+const { launchNewBrowser } = nst.devtool();
+launchNewBrowser(config);
+```
+
+response data:
+
+```js
+{
+  "port": 0,
+  "webSocketDebuggerUrl": "string"
+}
+```
+
+### launchExistBrowser
+
+launch exist browser
+[Detail docs](https://apidocs.nstbrowser.io/api-5418531)
+```ts
+const { launchExistBrowser } = nst.devtool();
+launchExistBrowser(profileId: string, {
+	config?: string,
+});
+```
+
+response data:
+
+```js
+{
+  "port": 0,
+  "webSocketDebuggerUrl": "string"
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
-# NST BROWSER NODE SDK
-Nst browser node sdk
+# Nstbrowser SDK for Node.js
 
-## Installing
+A Node.js SDK for interacting with [Nstbrowser API v2](https://apidocs.nstbrowser.io/)
+
+> **Note**: This documentation is for API v2, which is the recommended version with complete functionality from v1 plus additional features. For v1 documentation, please refer to [README-v1.md](./README-v1.md). New users are encouraged to use v2 for a more stable and standardized experience.
+
+## Overview
+
+This SDK implements Nstbrowser API v2, providing a comprehensive set of tools for managing browser profiles, controlling browser instances, managing local browser data, and utilizing Chrome DevTools Protocol (CDP) for browser automation.
+
+The SDK enables you to:
+- Create and manage browser profiles with detailed fingerprint configurations
+- Start and stop browser instances individually or in batch
+- Configure and manage proxies for profiles
+- Manage profile tags for better organization
+- Clear browser cache and cookies
+- Connect to browsers using Chrome DevTools Protocol (CDP)
+- Automate browser actions through CDP integration with Puppeteer
+
+## Installation
+
 Using npm:
 
 ```bash
@@ -20,428 +37,122 @@ Using yarn:
 $ yarn add nstbrowser-sdk-node
 ```
 
-## How To Use
+## Getting Started
 
-javascript:
+To use the SDK, you need an API key from Nstbrowser:
 
-```js
-import { NstBrowser } from 'nstbrowser-sdk-node';
+```javascript
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
 
-const nst = new NstBrowser('your api key', {
+// Initialize the client with your API key
+const client = new NstBrowserV2('your_api_key', {
   timeout: 60000,
-  apiAddress: 'http://localhost:8848/api/agent'
+  apiAddress: 'http://localhost:8848/api/v2'
 });
-const { getLatestVersion } = nst.agentManager();
-getLatestVersion();
+
+// Now you can use the various services
+const profileId = 'your_profile_id';
+
+// Start a browser instance
+const startResponse = await client.browsers.startBrowser({ profileId });
+console.log('Browser started:', startResponse);
+
+// Stop the browser instance
+const stopResponse = await client.browsers.stopBrowser({ profileId });
+console.log('Browser stopped:', stopResponse);
 ```
 
-typescript:
+## CDP Integration with Puppeteer
 
-```ts
-import { NstBrowser, NstBrowserTypes } from 'nstbrowser-sdk-node';
+One of the most powerful features of the SDK is its seamless integration with Puppeteer for browser automation:
 
-const nst: NstBrowserTypes = new NstBrowser('your api key', {
-  timeout: 60000,
-  apiAddress: 'http://localhost:8848/api/agent'
-});
-const { getLatestVersion } = nst.agentManager();
-getLatestVersion();
-```
+```javascript
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+import puppeteer from 'puppeteer-core';
 
-Browserless:
-
-```js
-import { Browserless } from 'nstbrowser-sdk-node';
-
-const browserless = new Browserless({
-  apiKey: 'your api key',
-  proxy: 'your proxy', // required
-})
-
-browserless.load('https://nstbrowser.io').then(text => {
+async function automateWithPuppeteer() {
+  const client = new NstBrowserV2('your_api_key');
   
-})
-```
+  // Connect to a browser using CDP
+  const cdpResponse = await client.cdpEndpoints.connectBrowser({
+    profileId: 'your_profile_id',
+    config: {
+      headless: false,
+      autoClose: false
+    }
+  });
 
-## NstBrowser Node Sdk Response Schema:
+  // Connect Puppeteer to the browser instance
+  const browser = await puppeteer.connect({
+    browserWSEndpoint: cdpResponse.data.webSocketDebuggerUrl,
+    defaultViewport: null
+  });
 
-```js
-{
-  // `data` is the response
-  "data": {},
-    
-  // `code` is the HTTP status code
-  "code": 200,
+  // Use Puppeteer for automation
+  const page = await browser.newPage();
+  await page.goto('https://example.com');
   
-  // `err` is the request's status
-  "err": false,
-  
-  "msg": "success"
+  // ... perform other actions
 }
 ```
 
+## Examples
 
+The SDK comes with a comprehensive set of examples in the `/examples/v2` directory. To run the examples:
 
-## BrowserManager
-
-### forceStart
-
-force start the browser by profileId
-```ts
-const { forceStart } = nst.browserManager();
-forceStart(profileId: string);
+1. Navigate to the examples directory and install dependencies:
+```bash
+cd examples/v2
+npm install
 ```
 
-### start
-
-start the browser by profileId
-
-```ts
-const { start } = nst.browserManager();
-start(profileId: string);
+2. Create a `.env` file in the `examples/v2` directory and add your API key:
+```bash
+echo "nstbrowser_api_key=your-api-key" > .env
 ```
 
-### startSome
-
-batch start browser by profileIds
-
-```ts
-const { startSome } = nst.browserManager();
-startSome(profileIds: string[]);
+3. Run any example:
+```bash
+node browsers/startBrowser.js
 ```
 
-### stop
-
-stop the browser by profileId
-
-```ts
-const { stop } = nst.browserManager();
-stop(profileId: string);
-```
-
-### stopSome
-
-batch stop browser by profileIds
-
-```ts
-const { stopSome } = nst.browserManager();
-stopSome(profileIds: string[]);
-```
-
-### stopAll
-
-stop all running browser
-
-```ts
-const { stopAll } = nst.browserManager();
-stopAll();
-```
-
-### getRunningBrowserAll
-
-get all running browser's info
-
-```ts
-const { getRunningBrowserAll } = nst.browserManager();
-getRunningBrowserAll();
-```
-
-response data:
-
-```js
-[
-  {
-    profileId: "string",
-    name: "string",
-    version: "string",
-    kernelType: "string", // nstchrome | nstfirefox
-    running: "boolean",
-    userDirPath: "string"
-  }
-]
-```
-
-### getRemoteDebuggingAddress
-
-get browser remote web socket debugging url
-
-```ts
-const { getRemoteDebuggingAddress } = nst.browserManager();
-getRemoteDebuggingAddress(profileId: string);
-```
-
-### getProfilesStatus
-
-get all profiles status
-```ts
-const { getProfilesStatus } = nst.browserManager();
-getProfilesStatus();
-```
-
-
-
-## ProfileManager
-
-### createProfile
-
-create profile
-
-[Detail docs](https://apidocs.nstbrowser.io/api-5496096)
-
-```ts
-const { createProfile } = nst.profileManager();
-createProfile({
-  "kernel": "chromium",
-  "kernelMilestone": "120",
-  "name": "Profile",
-  "platform": "windows"
-});
-```
-
-response data:
-```js
-{
-  "_id": "string",
-  "createdAt": "string",
-  "fingerprintId": "string",
-  "groupId": "string",
-  "kernel": 0,
-  "kernelMilestone": "string",
-  "kernelVersion": "string",
-  "name": "string",
-  "note": "string",
-  "platform": 0,
-  "platformVersion": "string",
-  "profileId": "string",
-  "saveLocal": true,
-  "status": 0,
-  "tags": [
-    "string"
-  ],
-  "teamId": "string",
-  "uaFullVersion": "string",
-  "updatedAt": "string",
-  "userId": "string"
-}
-```
-
-### deleteProfile
-
-delete profile by profileId
-
-```ts
-const { deleteProfile } = nst.profileManager();
-deleteProfile(profileId: string);
-```
-
-### profiles
-
-list profiles
-
-```ts
-const { profiles } = nst.profileManager();
-profiles({
-  	page: 1,
-	  pageSize: 10,
-  	s: '',
-  	groupId: ''
-});
-```
-
-response data:
-
-```js
-"data": {
-    "docs": [
-        {
-            "fingerprintId": "string",
-            "groupId": "string",
-            "kernel": 0,
-            "kernelMilestone": "string",
-            "kernelVersion": "string",
-            "name": "string",
-            "note": "string",
-            "platform": 0,
-            "platformVersion": "string",
-            "profileId": "string",
-            "proxyConfig": {
-                "checker": "string",
-                "host": "string",
-                "password": "string",
-                "port": "string",
-                "protocol": "string",
-                "proxySetting": "string",
-                "proxyType": "string",
-                "url": "string",
-                "username": "string"
-            },
-            "tags": [
-                "string"
-            ],
-            "teamId": "string",
-            "uaFullVersion": "string",
-            "userId": "string"
-        }
-    ],
-    "hasNextPage": true,
-    "hasPrevPage": true,
-    "limit": 0,
-    "nextPage": 0,
-    "offset": 0,
-    "page": 0,
-    "pagingCounter": 0,
-    "prevPage": 0,
-    "totalDocs": 0,
-    "totalPages": 0
-}
-```
-
-### batchUpdateProxy
-
-batch update proxy for profiles, if proxy url is empty,you should set value to: protocol、host and port, otherwise set proxy url just fine.
-
-```ts
-const { batchUpdateProxy } = nst.profileManager();
-batchUpdateProxy({
-  "profileIds": ["string"],
-  "proxyConfig": {
-    "checker": "string",
-    "host": "string",
-    "password": "string",
-    "port": "string",
-    "protocol": "string",
-    "proxySetting": "string",
-    "proxyType": "string",
-    "url": "string",
-    "username": "string"
-  }
-});
-```
-
-### getProfileTags
-get all profile tags
-
-```ts
-const { getProfileTags } = nst.profileManager();
-getProfileTags();
-```
-
-response data:
-
-```js
-[
-  {
-    color: "string",
-    name: "string",
-  }
-]
-```
-
-### batchUpdateProfileTags
-batch update profile tags
-
-```ts
-const { batchUpdateProfileTags } = nst.profileManager();
-
-batchUpdateProfileTags({
-  "profileIds": string[],
-  "tags": {
-    "color": string;
-    "name": string;
-  }[]
-});
-```
-
-### batchCreateProfileTags
-batch create profile tags
-
-```ts
-const { batchCreateProfileTags } = nst.profileManager();
-
-batchCreateProfileTags({
-  "profileIds": string[],
-  "tags": {
-    "color": string;
-    "name": string;
-  }[]
-});
-```
-
-### batchClearProfileTags
-
-batch clear profile tags
-
-```ts
-const { batchClearProfileTags } = nst.profileManager();
-
-batchClearProfileTags({
-  "profileIds": ["string"]
-});
-```
-
-### clearCookies
-
-clear local cookies by profileId
-
-```ts
-const { clearCookies } = nst.profileManager();
-clearCookies("profileId")
-```
-
-### clearProfileCache
-
-clear user profile dir.
-
-```ts
-const { clearProfileCache } = nst.profileManager();
-clearProfileCache("profileId")
-```
-
-### batchClearProfileCache
-
-batch clear user profile dir.
-
-```ts
-const { batchClearProfileCache } = nst.profileManager();
-batchClearProfileCache(["profileId"])
-```
-
-## Devtool
-
-### launchNewBrowser
-
-launch new browser
-[Detail docs](https://apidocs.nstbrowser.io/api-5418530)
-```ts
-const { launchNewBrowser } = nst.devtool();
-launchNewBrowser(config);
-```
-
-response data:
-
-```js
-{
-  "port": 0,
-  "webSocketDebuggerUrl": "string"
-}
-```
-
-### launchExistBrowser
-
-launch exist browser
-[Detail docs](https://apidocs.nstbrowser.io/api-5418531)
-```ts
-const { launchExistBrowser } = nst.devtool();
-launchExistBrowser(profileId: string, {
-	config?: string,
-});
-```
-
-response data:
-
-```js
-{
-  "port": 0,
-  "webSocketDebuggerUrl": "string"
-}
-```
+Available examples are organized by service:
+
+### Browser Examples
+- `browsers/getBrowserDebugger.js`: Get browser debugger information for automation
+- `browsers/getBrowserPages.js`: Get information about browser pages
+- `browsers/getBrowsers.js`: Get list of active browsers with status information
+- `browsers/startBrowser.js`: Start a browser for a specific profile
+- `browsers/startBrowsers.js`: Start multiple browsers in batch
+- `browsers/startOnceBrowser.js`: Start a once-off browser with custom configuration
+- `browsers/stopBrowser.js`: Stop a specific browser instance
+- `browsers/stopBrowsers.js`: Stop multiple browser instances in batch
+
+### Profile Examples
+- `profiles/batchClearProfileTags.js`: Clear tags for multiple profiles in batch
+- `profiles/batchCreateProfileTags.js`: Create tags for multiple profiles in batch
+- `profiles/batchResetProfileProxy.js`: Reset proxies for multiple profiles in batch
+- `profiles/batchUpdateProfileTags.js`: Update tags for multiple profiles in batch
+- `profiles/batchUpdateProxy.js`: Update proxies for multiple profiles in batch
+- `profiles/clearProfileTags.js`: Clear all tags from a specific profile
+- `profiles/createProfile.js`: Create a new profile with detailed configuration
+- `profiles/createProfileTags.js`: Create new tags for a specific profile
+- `profiles/deleteProfile.js`: Delete a specific profile
+- `profiles/deleteProfiles.js`: Delete multiple profiles in batch
+- `profiles/getProfileTags.js`: Get all tags associated with profiles
+- `profiles/getProfiles.js`: Get profiles with filtering options
+- `profiles/resetProfileProxy.js`: Reset proxy configuration for a specific profile
+- `profiles/updateProfileProxy.js`: Update proxy configuration for a specific profile
+- `profiles/updateProfileTags.js`: Update tags for a specific profile
+
+### Local Data Examples
+- `locals/clearProfileCache.js`: Clear browser cache for a specific profile
+- `locals/clearProfileCookies.js`: Clear browser cookies for a specific profile
+
+### CDP Endpoint Examples
+- `cdpEndpoints/connectBrowser.js`: Connect to a browser using CDP and automate with Puppeteer
+- `cdpEndpoints/connectOnceBrowser.js`: Connect to a once-off browser with CDP and automate with Puppeteer
+
+## Support
+
+For support, feel free to reach out to us via [Discord](https://api.nstbrowser.io/api/v1/links/discord). For more detailed documentation, visit the official Nstbrowser documentation: [Nstbrowser API Documentation](https://apidocs.nstbrowser.io).

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ const client = new NstBrowserV2('your_api_key', {
 const profileId = 'your_profile_id';
 
 // Start a browser instance
-const startResponse = await client.browsers.startBrowser({ profileId });
+const startResponse = await client.browsers().startBrowser({ profileId });
 console.log('Browser started:', startResponse);
 
 // Stop the browser instance
-const stopResponse = await client.browsers.stopBrowser({ profileId });
+const stopResponse = await client.browsers().stopBrowser({ profileId });
 console.log('Browser stopped:', stopResponse);
 ```
 
@@ -74,7 +74,7 @@ async function automateWithPuppeteer() {
   const client = new NstBrowserV2('your_api_key');
   
   // Connect to a browser using CDP
-  const cdpResponse = await client.cdpEndpoints.connectBrowser({
+  const cdpResponse = await client.cdpEndpoints().connectBrowser({
     profileId: 'your_profile_id',
     config: {
       headless: false,

--- a/examples/v2/browsers/getBrowserDebugger.js
+++ b/examples/v2/browsers/getBrowserDebugger.js
@@ -1,0 +1,31 @@
+/**
+ * Example demonstrating how to get debugger information for a specific browser.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to get browser debugger information
+const profileId = 'your_profile_id';
+
+async function getBrowserDebugger() {
+  try {
+    const response = await client.browsers().getBrowserDebugger(profileId);
+    console.log(`Debugger information for browser with profile ${profileId}:`);
+    console.log('Response:', response);
+
+    // Extract and print the debugger URL if available
+    if (response?.data?.webSocketDebuggerUrl) {
+      const debuggerUrl = response.data.webSocketDebuggerUrl;
+      console.log(`\nDebugger URL: ${debuggerUrl}`);
+    }
+  } catch (error) {
+    console.error('Failed to get browser debugger information:', error);
+  }
+}
+
+// Execute the example
+getBrowserDebugger(); 

--- a/examples/v2/browsers/getBrowserPages.js
+++ b/examples/v2/browsers/getBrowserPages.js
@@ -1,0 +1,34 @@
+/**
+ * Example demonstrating how to get pages information for a specific browser.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to get browser pages
+const profileId = 'your_profile_id';
+
+async function getBrowserPages() {
+  try {
+    const response = await client.browsers().getBrowserPages(profileId);
+    console.log(`Pages for browser with profile ${profileId}:`);
+    console.log('Response:', response);
+
+    // Print a list of page URLs if available
+    if (response && response.data) {
+      const pages = response.data;
+      console.log('\nPage info:');
+      pages.forEach((page, index) => {
+        console.log(`${index + 1}. ${page}`);
+      });
+    }
+  } catch (error) {
+    console.error('Failed to get browser pages:', error);
+  }
+}
+
+// Execute the example
+getBrowserPages(); 

--- a/examples/v2/browsers/getBrowsers.js
+++ b/examples/v2/browsers/getBrowsers.js
@@ -1,0 +1,28 @@
+/**
+ * Example demonstrating how to get a list of browsers with optional status filtering.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+async function getBrowsers() {
+  try {
+    // Get all browsers
+    const response = await client.browsers().getBrowsers();
+    console.log('All browsers:');
+    console.log('Response:', response);
+
+    // Get browsers with a specific status (e.g., starting, running, stopping)
+    const statusResponse = await client.browsers().getBrowsers('running');
+    console.log('\nRunning browsers:');
+    console.log('Response:', statusResponse);
+  } catch (error) {
+    console.error('Failed to get browsers:', error);
+  }
+}
+
+// Execute the example
+getBrowsers(); 

--- a/examples/v2/browsers/startBrowser.js
+++ b/examples/v2/browsers/startBrowser.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to start a browser for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID you want to start a browser for
+const profileId = 'your_profile_id';
+
+async function startBrowser() {
+  try {
+    const response = await client.browsers().startBrowser(profileId);
+    console.log(`Browser started successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to start browser:', error);
+  }
+}
+
+// Execute the example
+startBrowser(); 

--- a/examples/v2/browsers/startBrowsers.js
+++ b/examples/v2/browsers/startBrowsers.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to start multiple browsers in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define a list of profile IDs to start browsers for
+const profileIds = ['profile_id_1', 'profile_id_2', 'profile_id_3'];
+
+async function startBrowsers() {
+  try {
+    const response = await client.browsers().startBrowsers(profileIds);
+    console.log(`Browsers started successfully for ${profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to start browsers:', error);
+  }
+}
+
+// Execute the example
+startBrowsers(); 

--- a/examples/v2/browsers/startOnceBrowser.js
+++ b/examples/v2/browsers/startOnceBrowser.js
@@ -1,0 +1,75 @@
+/**
+ * Example demonstrating how to start a once-off browser with custom configuration.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the configuration for the once-off browser
+const config = {
+  name: 'testProfile',
+  platform: 'Windows',
+  kernelMilestone: '132',
+  autoClose: true,
+  timedCloseSec: 30,
+  headless: false,
+  incognito: false,
+  proxy: 'http://admin:123456@127.0.0.1:8000',
+  skipProxyChecking: true,
+  fingerprint: {
+    flags: {
+      audio: 'Noise',
+      battery: 'Masked',
+      canvas: 'Noise',
+      clientRect: 'Noise',
+      fonts: 'Masked',
+      geolocation: 'Custom',
+      geolocationPopup: 'Prompt',
+      gpu: 'Allow',
+      localization: 'Custom',
+      screen: 'Custom',
+      speech: 'Masked',
+      timezone: 'Custom',
+      webgl: 'Noise',
+      webrtc: 'Custom',
+    },
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.6998.45 Safari/537.36',
+    deviceMemory: 8,
+    hardwareConcurrency: 16,
+    disableImageLoading: true,
+    doNotTrack: true,
+    localization: {
+      language: 'zh-HK',
+      languages: ['zh-HK', 'en-US', 'en'],
+      timezone: 'Asia/Hong_Kong',
+    },
+    screen: { width: 1280, height: 1024 },
+    geolocation: {
+      latitude: '31.2333',
+      longitude: '121.469',
+      accuracy: '603',
+    },
+    webrtc: { publicIp: '111.111.111.111' },
+  },
+  startupUrls: ['https://www.nstbrowser.io'],
+  args: {
+    '--remote-debugging-port': 34543,
+    'disable-backgrounding-occluded-windows': true,
+  },
+};
+
+async function startOnceBrowser() {
+  try {
+    const response = await client.browsers().startOnceBrowser(config);
+    console.log('Once-off browser started successfully');
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to start once-off browser:', error);
+  }
+}
+
+// Execute the example
+startOnceBrowser(); 

--- a/examples/v2/browsers/stopBrowser.js
+++ b/examples/v2/browsers/stopBrowser.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to stop a browser for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to stop the browser
+const profileId = 'your_profile_id';
+
+async function stopBrowser() {
+  try {
+    const response = await client.browsers().stopBrowser(profileId);
+    console.log(`Browser stopped successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to stop browser:', error);
+  }
+}
+
+// Execute the example
+stopBrowser(); 

--- a/examples/v2/browsers/stopBrowsers.js
+++ b/examples/v2/browsers/stopBrowsers.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to stop multiple browsers in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define a list of profile IDs for which you want to stop browsers
+const profileIds = ['profile_id_1', 'profile_id_2', 'profile_id_3'];
+
+async function stopBrowsers() {
+  try {
+    const response = await client.browsers().stopBrowsers(profileIds);
+    console.log(`Browsers stopped successfully for ${profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to stop browsers:', error);
+  }
+}
+
+// Execute the example
+stopBrowsers(); 

--- a/examples/v2/cdpEndpoints/connectBrowser.js
+++ b/examples/v2/cdpEndpoints/connectBrowser.js
@@ -1,0 +1,97 @@
+/**
+ * Example demonstrating how to connect to a browser using Chrome DevTools Protocol
+ * and control it using puppeteer-core.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+import puppeteer from 'puppeteer-core'
+
+async function getCdpWebsocketUrl() {
+  const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+  const profileId = 'your_profile_id';
+  const config = {
+    headless: false, // False to see the browser UI
+    autoClose: false, // False to keep the browser open after the script ends
+  };
+
+  try {
+    // Initialize the client
+    const client = new NstBrowserV2(apiKey);
+    console.log(`Initialized NstBrowserV2, connecting to profile: ${profileId}`);
+
+    // Connect to the browser
+    const response = await client.cdpEndpoints().connectBrowser(profileId, config);
+    console.log(`Successfully connected to browser for profile ${profileId}`);
+
+    // Extract WebSocket endpoint if available
+    if (response?.data?.webSocketDebuggerUrl) {
+      const wsEndpoint = response.data.webSocketDebuggerUrl;
+      console.log(`WebSocket endpoint: ${wsEndpoint}`);
+      return wsEndpoint;
+    } else {
+      console.log('WebSocket endpoint not found in response');
+      return null;
+    }
+  } catch (error) {
+    console.error('Failed to connect to browser:', error);
+    return null;
+  }
+}
+
+async function controlBrowserWithPuppeteer(websocketUrl) {
+  try {
+    console.log('\nConnecting to browser with puppeteer-core...');
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: websocketUrl,
+      defaultViewport: null,
+    });
+
+    // Get the default page or create a new one
+    const pages = await browser.pages();
+    const page = pages[0] || await browser.newPage();
+
+    console.log('Navigating to example.com...');
+    await page.goto('https://example.com');
+
+    const title = await page.title();
+    console.log(`Page title: ${title}`);
+
+    console.log('Taking screenshot...');
+    await page.screenshot({ path: 'example_screenshot.png' });
+    console.log('Screenshot saved to example_screenshot.png');
+
+    const content = await page.$eval('h1', (el) => el.textContent);
+    console.log(`H1 content: ${content}`);
+
+    console.log('Waiting for 3 seconds...');
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Close the connection
+    await page.close();
+    await browser.disconnect();
+    console.log('Puppeteer connection closed');
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      console.log('puppeteer-core is not installed. Please install it with: npm install puppeteer-core');
+    } else {
+      console.error('Error during Puppeteer automation:', error);
+    }
+  }
+}
+
+async function main() {
+  // Step 1: Get the CDP WebSocket URL
+  const websocketUrl = await getCdpWebsocketUrl();
+
+  // Step 2: Use the WebSocket URL with Puppeteer if available
+  if (websocketUrl) {
+    console.log('\nStarting Puppeteer automation...');
+    await controlBrowserWithPuppeteer(websocketUrl);
+  } else {
+    console.log('Cannot proceed with Puppeteer automation: WebSocket URL not available');
+  }
+}
+
+// Execute the example
+main(); 

--- a/examples/v2/cdpEndpoints/connectOnceBrowser.js
+++ b/examples/v2/cdpEndpoints/connectOnceBrowser.js
@@ -1,0 +1,146 @@
+/**
+ * Example demonstrating how to connect to a once-off browser using Chrome DevTools Protocol
+ * and control it using puppeteer-core.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+import puppeteer from 'puppeteer-core'
+
+async function getCdpWebsocketUrl() {
+  const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+  const config = {
+    name: 'testProfile',
+    platform: 'Windows',
+    kernelMilestone: '132',
+    autoClose: false,
+    timedCloseSec: 30,
+    headless: false,
+    incognito: false,
+    // proxy: 'http://admin:123456@127.0.0.1:8000',
+    skipProxyChecking: true,
+    fingerprint: {
+      flags: {
+        audio: 'Noise',
+        battery: 'Masked',
+        canvas: 'Noise',
+        clientRect: 'Noise',
+        fonts: 'Masked',
+        geolocation: 'Custom',
+        geolocationPopup: 'Prompt',
+        gpu: 'Allow',
+        localization: 'Custom',
+        screen: 'Custom',
+        speech: 'Masked',
+        timezone: 'Custom',
+        webgl: 'Noise',
+        webrtc: 'Custom',
+      },
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.6998.45 Safari/537.36',
+      deviceMemory: 8,
+      hardwareConcurrency: 16,
+      disableImageLoading: true,
+      doNotTrack: true,
+      localization: {
+        language: 'zh-HK',
+        languages: ['zh-HK', 'en-US', 'en'],
+        timezone: 'Asia/Hong_Kong',
+      },
+      screen: { width: 1280, height: 1024 },
+      geolocation: {
+        latitude: '31.2333',
+        longitude: '121.469',
+        accuracy: '603',
+      },
+      webrtc: { publicIp: '111.111.111.111' },
+    },
+    startupUrls: ['https://www.nstbrowser.io'],
+    args: {
+      '--remote-debugging-port': 34543,
+      'disable-backgrounding-occluded-windows': true,
+    },
+  };
+
+  try {
+    // Initialize the client
+    const client = new NstBrowserV2(apiKey);
+    console.log('Initialized NstBrowserV2, connecting to once-off browser');
+
+    // Connect to the browser
+    const response = await client.cdpEndpoints().connectOnceBrowser(config);
+    console.log('Successfully connected to once-off browser');
+
+    // Extract WebSocket endpoint if available
+    if (response?.data?.webSocketDebuggerUrl) {
+      const wsEndpoint = response.data.webSocketDebuggerUrl;
+      console.log(`WebSocket endpoint: ${wsEndpoint}`);
+      return wsEndpoint;
+    } else {
+      console.log('WebSocket endpoint not found in response');
+      if (response?.data) {
+        console.log(`Available data keys: ${Object.keys(response.data)}`);
+      }
+      return null;
+    }
+  } catch (error) {
+    console.error('Failed to connect to once-off browser:', error);
+    return null;
+  }
+}
+
+async function controlBrowserWithPuppeteer(websocketUrl) {
+  try {
+    console.log('\nConnecting to browser with puppeteer-core...');
+    const browser = await puppeteer.connect({
+      browserWSEndpoint: websocketUrl,
+      defaultViewport: null,
+    });
+
+    // Get the default page or create a new one
+    const pages = await browser.pages();
+    const page = pages[0] || await browser.newPage();
+
+    console.log('Navigating to example.com...');
+    await page.goto('https://example.com');
+
+    const title = await page.title();
+    console.log(`Page title: ${title}`);
+
+    console.log('Taking screenshot...');
+    await page.screenshot({ path: 'example_screenshot.png' });
+    console.log('Screenshot saved to example_screenshot.png');
+
+    const content = await page.$eval('h1', (el) => el.textContent);
+    console.log(`H1 content: ${content}`);
+
+    console.log('Waiting for 3 seconds...');
+    await new Promise(resolve => setTimeout(resolve, 3000));
+
+    // Close the connection
+    await page.close();
+    await browser.disconnect();
+    console.log('Puppeteer connection closed');
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      console.log('puppeteer-core is not installed. Please install it with: npm install puppeteer-core');
+    } else {
+      console.error('Error during Puppeteer automation:', error);
+    }
+  }
+}
+
+async function main() {
+  // Step 1: Get the CDP WebSocket URL
+  const websocketUrl = await getCdpWebsocketUrl();
+
+  // Step 2: Use the WebSocket URL with Puppeteer if available
+  if (websocketUrl) {
+    console.log('\nStarting Puppeteer automation...');
+    await controlBrowserWithPuppeteer(websocketUrl);
+  } else {
+    console.log('Cannot proceed with Puppeteer automation: WebSocket URL not available');
+  }
+}
+
+// Execute the example
+main(); 

--- a/examples/v2/locals/clearProfileCache.js
+++ b/examples/v2/locals/clearProfileCache.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to clear the cache for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to clear cache
+const profileId = 'your_profile_id';
+
+async function clearProfileCache() {
+  try {
+    const response = await client.locals().clearProfileCache(profileId);
+    console.log(`Cache cleared successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to clear profile cache:', error);
+  }
+}
+
+// Execute the example
+clearProfileCache(); 

--- a/examples/v2/locals/clearProfileCookies.js
+++ b/examples/v2/locals/clearProfileCookies.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to clear the cookies for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to clear cookies
+const profileId = 'your_profile_id';
+
+async function clearProfileCookies() {
+  try {
+    const response = await client.locals().clearProfileCookies(profileId);
+    console.log(`Cookies cleared successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to clear profile cookies:', error);
+  }
+}
+
+// Execute the example
+clearProfileCookies(); 

--- a/examples/v2/package-lock.json
+++ b/examples/v2/package-lock.json
@@ -1,0 +1,949 @@
+{
+  "name": "examples-v2",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "examples-v2",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "devDependencies": {
+        "nstbrowser-sdk-node": "file:../../",
+        "puppeteer-core": "^24.4.0"
+      }
+    },
+    "../..": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@rollup/plugin-replace": "^5.0.7",
+        "axios": "^1.7.7",
+        "form-data": "^4.0.1",
+        "puppeteer-core": "23.3.0"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.8",
+        "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^15.3.0",
+        "@rollup/plugin-terser": "^0.4.4",
+        "@rollup/plugin-typescript": "^11.1.6",
+        "@types/node": "^20.16.12",
+        "chai": "^5.1.1",
+        "nodemon": "^3.1.7",
+        "rollup": "^3.29.5",
+        "rollup-plugin-dts": "^6.1.1",
+        "ts-node": "^10.9.2",
+        "tslib": "^2.8.0",
+        "tsx": "^4.19.1",
+        "typescript": "^5.6.3"
+      }
+    },
+    "../../dist": {
+      "extraneous": true
+    },
+    ".yalc/nstbrowser-sdk-node": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "@rollup/plugin-replace": "^5.0.7",
+        "axios": "^1.7.7",
+        "form-data": "^4.0.1",
+        "puppeteer-core": "23.3.0"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmmirror.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.13.14",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.13.14.tgz",
+      "integrity": "sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmmirror.com/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmmirror.com/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmmirror.com/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/bare-fs/-/bare-fs-4.0.2.tgz",
+      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmmirror.com/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmmirror.com/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmmirror.com/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmmirror.com/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmmirror.com/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmmirror.com/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmmirror.com/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "dev": true,
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nstbrowser-sdk-node": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmmirror.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.4.0",
+      "resolved": "https://registry.npmmirror.com/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
+      "integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
+      "dev": true,
+      "dependencies": {
+        "@puppeteer/browsers": "2.8.0",
+        "chromium-bidi": "2.1.2",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1413902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmmirror.com/@puppeteer/browsers/-/browsers-2.8.0.tgz",
+      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.1",
+        "tar-fs": "^3.0.8",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/chromium-bidi": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
+      "integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1413902",
+      "resolved": "https://registry.npmmirror.com/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
+      "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ==",
+      "dev": true
+    },
+    "node_modules/puppeteer-core/node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmmirror.com/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "dev": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmmirror.com/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true
+    },
+    "node_modules/streamx": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmmirror.com/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmmirror.com/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "dev": true,
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmmirror.com/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmmirror.com/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmmirror.com/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/examples/v2/package.json
+++ b/examples/v2/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "examples-v2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "preinstall": "cd ../.. && pnpm install && pnpm run build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "nstbrowser-sdk-node": "file:../../",
+    "puppeteer-core": "^24.4.0"
+  }
+}

--- a/examples/v2/profiles/batchClearProfileTags.js
+++ b/examples/v2/profiles/batchClearProfileTags.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to clear tags for multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define a list of profile IDs for which you want to clear tags
+const profileIds = ['profile_id_1', 'profile_id_2', 'profile_id_3'];
+
+async function batchClearProfileTags() {
+  try {
+    const response = await client.profiles().batchClearProfileTags(profileIds);
+    console.log(`Tags cleared successfully for ${profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch clear profile tags:', error);
+  }
+}
+
+// Execute the example
+batchClearProfileTags(); 

--- a/examples/v2/profiles/batchCreateProfileTags.js
+++ b/examples/v2/profiles/batchCreateProfileTags.js
@@ -1,0 +1,34 @@
+/**
+ * Example demonstrating how to create tags for multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the batch tags data
+const batchTagsData = {
+  profileIds: ['profile_id_1', 'profile_id_2', 'profile_id_3'],
+  tags: [
+    { name: 'social', color: '#646AEE' },
+    { name: 'marketing', color: '#646AEE' },
+    { name: 'testing', color: '#646AEE' },
+  ],
+};
+
+async function batchCreateProfileTags() {
+  try {
+    const response = await client.profiles().batchCreateProfileTags(batchTagsData);
+    console.log(
+      `Tags ${JSON.stringify(batchTagsData.tags)} created for ${batchTagsData.profileIds.length} profiles`
+    );
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch create profile tags:', error);
+  }
+}
+
+// Execute the example
+batchCreateProfileTags(); 

--- a/examples/v2/profiles/batchResetProfileProxy.js
+++ b/examples/v2/profiles/batchResetProfileProxy.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to reset proxies for multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define a list of profile IDs for which you want to reset proxies
+const profileIds = ['profile_id_1', 'profile_id_2', 'profile_id_3'];
+
+async function batchResetProfileProxy() {
+  try {
+    const response = await client.profiles().batchResetProfileProxy(profileIds);
+    console.log(`Proxies reset successfully for ${profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch reset profile proxies:', error);
+  }
+}
+
+// Execute the example
+batchResetProfileProxy(); 

--- a/examples/v2/profiles/batchUpdateProfileTags.js
+++ b/examples/v2/profiles/batchUpdateProfileTags.js
@@ -1,0 +1,34 @@
+/**
+ * Example demonstrating how to update tags for multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the batch update tags data
+const batchUpdateData = {
+  profileIds: ['profile_id_1', 'profile_id_2', 'profile_id_3'],
+  tags: [
+    { name: 'social', color: '#646AEE' },
+    { name: 'marketing', color: '#646AEE' },
+    { name: 'testing', color: '#646AEE' },
+  ],
+};
+
+async function batchUpdateProfileTags() {
+  try {
+    const response = await client.profiles().batchUpdateProfileTags(batchUpdateData);
+    console.log(
+      `Tags ${JSON.stringify(batchUpdateData.tags)} updated for ${batchUpdateData.profileIds.length} profiles`
+    );
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch update profile tags:', error);
+  }
+}
+
+// Execute the example
+batchUpdateProfileTags(); 

--- a/examples/v2/profiles/batchUpdateProxy.js
+++ b/examples/v2/profiles/batchUpdateProxy.js
@@ -1,0 +1,30 @@
+/**
+ * Example demonstrating how to update proxies for multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the proxy data for batch update
+const proxyData = {
+  profileIds: ['profile_id_1', 'profile_id_2', 'profile_id_3'],
+  proxyConfig: {
+    url: 'http://admin:654321@127.0.0.1:8000',
+  },
+};
+
+async function batchUpdateProxy() {
+  try {
+    const response = await client.profiles().batchUpdateProxy(proxyData);
+    console.log(`Proxies updated successfully for ${proxyData.profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch update proxies:', error);
+  }
+}
+
+// Execute the example
+batchUpdateProxy(); 

--- a/examples/v2/profiles/clearProfileTags.js
+++ b/examples/v2/profiles/clearProfileTags.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to clear all tags for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to clear tags
+const profileId = 'your_profile_id';
+
+async function clearProfileTags() {
+  try {
+    const response = await client.profiles().clearProfileTags(profileId);
+    console.log(`Tags cleared successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to clear profile tags:', error);
+  }
+}
+
+// Execute the example
+clearProfileTags(); 

--- a/examples/v2/profiles/createProfile.js
+++ b/examples/v2/profiles/createProfile.js
@@ -1,0 +1,79 @@
+/**
+ * Example demonstrating how to create a new browser profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the data for the new profile
+const profileData = {
+  name: 'testProfile',
+  platform: 'Windows',
+  kernelMilestone: '132',
+  groupName: 'Default',
+  note: 'test profile note',
+  proxy: 'http://admin:123456@127.0.0.1:8000',
+  fingerprint: {
+    flags: {
+      audio: 'Noise',
+      battery: 'Masked',
+      canvas: 'Noise',
+      clientRect: 'Noise',
+      fonts: 'Masked',
+      geolocation: 'Custom',
+      geolocationPopup: 'Prompt',
+      gpu: 'Allow',
+      localization: 'Custom',
+      screen: 'Custom',
+      speech: 'Masked',
+      timezone: 'Custom',
+      webgl: 'Noise',
+      webrtc: 'Custom',
+    },
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.6834.83 Safari/537.36',
+    deviceMemory: 8,
+    hardwareConcurrency: 16,
+    disableImageLoading: true,
+    restoreLastSession: true,
+    doNotTrack: true,
+    localization: {
+      language: 'zh-HK',
+      languages: ['zh-HK', 'en-US', 'en'],
+      timezone: 'Asia/Hong_Kong',
+    },
+    screen: { width: 1280, height: 1024 },
+    geolocation: {
+      latitude: '31.2333',
+      longitude: '121.469',
+      accuracy: '603',
+    },
+    webrtc: { publicIp: '111.111.111.111' },
+  },
+  startupUrls: ['https://www.nstbrowser.io'],
+  args: {
+    '--remote-debugging-port': 34543,
+    '--disable-backgrounding-occluded-windows': true,
+  },
+};
+
+async function createProfile() {
+  try {
+    const response = await client.profiles().createProfile(profileData);
+    console.log('Profile created successfully');
+    console.log('Response:', response);
+
+    // Extract and print the new profile ID if available
+    if (response?.data?.profileId) {
+      const profileId = response.data.profileId;
+      console.log(`\nNew profile ID: ${profileId}`);
+    }
+  } catch (error) {
+    console.error('Failed to create profile:', error);
+  }
+}
+
+// Execute the example
+createProfile();

--- a/examples/v2/profiles/createProfileTags.js
+++ b/examples/v2/profiles/createProfileTags.js
@@ -1,0 +1,30 @@
+/**
+ * Example demonstrating how to create tags for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID and tags data
+const profileId = 'your_profile_id';
+const data = [
+  { name: 'social', color: '#646AEE' },
+  { name: 'marketing', color: '#646AEE' },
+  { name: 'testing', color: '#646AEE' },
+];
+
+async function createProfileTags() {
+  try {
+    const response = await client.profiles().createProfileTags(profileId, data);
+    console.log(`Tags created successfully for profile ${profileId}:`, data);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to create profile tags:', error);
+  }
+}
+
+// Execute the example
+createProfileTags(); 

--- a/examples/v2/profiles/deleteProfile.js
+++ b/examples/v2/profiles/deleteProfile.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to delete a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID to delete
+const profileId = '461d0bf2-9de8-4e24-8bd9-c7cbf045e4aa';
+
+async function deleteProfile() {
+  try {
+    const response = await client.profiles().deleteProfile(profileId);
+    console.log(`Profile ${profileId} deleted successfully`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to delete profile:', error);
+  }
+}
+
+// Execute the example
+deleteProfile(); 

--- a/examples/v2/profiles/deleteProfiles.js
+++ b/examples/v2/profiles/deleteProfiles.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to delete multiple profiles in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define a list of profile IDs to delete
+const profileIds = ['profile_id_1', 'profile_id_2', 'profile_id_3'];
+
+async function deleteProfiles() {
+  try {
+    const response = await client.profiles().deleteProfiles(profileIds);
+    console.log(`Successfully deleted ${profileIds.length} profiles`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to delete profiles:', error);
+  }
+}
+
+// Execute the example
+deleteProfiles(); 

--- a/examples/v2/profiles/getProfileTags.js
+++ b/examples/v2/profiles/getProfileTags.js
@@ -1,0 +1,31 @@
+/**
+ * Example demonstrating how to get all profile tags.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+async function getProfileTags() {
+  try {
+    const response = await client.profiles().getProfileTags();
+    console.log('Profile tags retrieved successfully');
+    console.log('Response:', response);
+
+    // Print a list of all unique tags if available
+    if (response?.data) {
+      const tags = response.data;
+      console.log('\nAvailable tags:');
+      tags.forEach((tag, index) => {
+        console.log(`${index + 1}. ${tag}`);
+      });
+    }
+  } catch (error) {
+    console.error('Failed to get profile tags:', error);
+  }
+}
+
+// Execute the example
+getProfileTags(); 

--- a/examples/v2/profiles/getProfiles.js
+++ b/examples/v2/profiles/getProfiles.js
@@ -1,0 +1,35 @@
+/**
+ * Example demonstrating how to get a list of profiles with optional filtering.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+async function getProfiles() {
+  try {
+    // Get all profiles
+    const response = await client.profiles().getProfiles();
+    console.log('All profiles:');
+    console.log('Response:', response);
+
+    // Get profiles with filtering
+    const filterData = {
+      page: 1,
+      pageSize: 10,
+      s: 'test',
+      tags: '',
+      groupId: '',
+    };
+    const filteredResponse = await client.profiles().getProfiles(filterData);
+    console.log('\nFiltered profiles:');
+    console.log('Response:', filteredResponse);
+  } catch (error) {
+    console.error('Failed to get profiles:', error);
+  }
+}
+
+// Execute the example
+getProfiles(); 

--- a/examples/v2/profiles/resetProfileProxy.js
+++ b/examples/v2/profiles/resetProfileProxy.js
@@ -1,0 +1,25 @@
+/**
+ * Example demonstrating how to reset a proxy for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to reset the proxy
+const profileId = 'your_profile_id';
+
+async function resetProfileProxy() {
+  try {
+    const response = await client.profiles().resetProfileProxy(profileId);
+    console.log(`Proxy reset successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to reset profile proxy:', error);
+  }
+}
+
+// Execute the example
+resetProfileProxy(); 

--- a/examples/v2/profiles/updateProfileProxy.js
+++ b/examples/v2/profiles/updateProfileProxy.js
@@ -1,0 +1,28 @@
+/**
+ * Example demonstrating how to update a proxy for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID for which you want to update the proxy
+const profileId = 'your_profile_id';
+const proxyConfig = {
+  url: 'http://admin:654321@127.0.0.1:8000',
+};
+
+async function updateProfileProxy() {
+  try {
+    const response = await client.profiles().updateProfileProxy(profileId, proxyConfig);
+    console.log(`Proxy updated successfully for profile ${profileId}`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to update profile proxy:', error);
+  }
+}
+
+// Execute the example
+updateProfileProxy(); 

--- a/examples/v2/profiles/updateProfileTags.js
+++ b/examples/v2/profiles/updateProfileTags.js
@@ -1,0 +1,31 @@
+/**
+ * Example demonstrating how to update tags for a specific profile.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile ID and updated tags data
+const profileId = 'your_profile_id';
+
+const updateTagsData = [
+  { name: 'social', color: '#646AEE' },
+  { name: 'marketing', color: '#646AEE' },
+  { name: 'testing', color: '#646AEE' },
+];
+
+async function updateProfileTags() {
+  try {
+    const response = await client.profiles().updateProfileTags(profileId, updateTagsData);
+    console.log(`Tags updated successfully for profile ${profileId}:`, updateTagsData);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to update profile tags:', error);
+  }
+}
+
+// Execute the example
+updateProfileTags(); 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nstbrowser-sdk-node",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "description": "nst browser node sdk",
   "main": "dist/main.js",
   "exports": {

--- a/src/controller/v2/browsers/browsers.controller.ts
+++ b/src/controller/v2/browsers/browsers.controller.ts
@@ -1,0 +1,71 @@
+import {
+  startBrowserService,
+  startBrowsersService,
+  startOnceBrowserService,
+  stopBrowserService,
+  stopBrowsersService,
+  getBrowsersService,
+  getBrowserPagesService,
+  getBrowserDebuggerService,
+} from '@/service/v2/browsers/browsers.service';
+
+import type {
+  SubClassConfig,
+  BrowserStatus,
+  StartOnceBrowserParam,
+} from '@/types';
+
+function browsersController(config: SubClassConfig) {
+  async function startBrowser(profileId: string) {
+    const data = await startBrowserService(config, profileId);
+    return data;
+  }
+
+  async function startBrowsers(profileIds: string[]) {
+    const data = await startBrowsersService(config, profileIds);
+    return data;
+  }
+
+  async function startOnceBrowser(param: StartOnceBrowserParam) {
+    const data = await startOnceBrowserService(config, param);
+    return data;
+  }
+
+  async function stopBrowser(profileId: string) {
+    const data = await stopBrowserService(config, profileId);
+    return data;
+  }
+
+  async function stopBrowsers(profileIds: string[]) {
+    const data = await stopBrowsersService(config, profileIds);
+    return data;
+  }
+
+  async function getBrowsers(status?: BrowserStatus) {
+    const data = await getBrowsersService(config, status);
+    return data;
+  }
+
+  async function getBrowserPages(profileId: string) {
+    const data = await getBrowserPagesService(config, profileId);
+    return data;
+  }
+
+  async function getBrowserDebugger(profileId: string) {
+    const data = await getBrowserDebuggerService(config, profileId);
+    return data;
+  }
+
+  return {
+    startBrowser,
+    startBrowsers,
+    startOnceBrowser,
+    stopBrowser,
+    stopBrowsers,
+    getBrowsers,
+    getBrowserPages,
+    getBrowserDebugger,
+  };
+}
+
+export default browsersController;

--- a/src/controller/v2/cdpEndpoints/cdpEndpoints.controller.ts
+++ b/src/controller/v2/cdpEndpoints/cdpEndpoints.controller.ts
@@ -1,0 +1,29 @@
+// cdp-endpoints.controller.ts
+import {
+  connectBrowserService,
+  connectOnceBrowserService,
+} from '@/service/v2/cdpEndpoints/cdpEndpoints.service';
+import {
+  SubClassConfig,
+  ConnectBrowserParam,
+  StartOnceBrowserParam,
+} from '@/types';
+
+function cdpEndpoints(config: SubClassConfig) {
+  async function connectBrowser(profileId: string, param: ConnectBrowserParam) {
+    const data = await connectBrowserService(config, profileId, param);
+    return data;
+  }
+
+  async function connectOnceBrowser(param: StartOnceBrowserParam) {
+    const data = await connectOnceBrowserService(config, param);
+    return data;
+  }
+
+  return {
+    connectBrowser,
+    connectOnceBrowser,
+  };
+}
+
+export default cdpEndpoints;

--- a/src/controller/v2/locals/locals.controller.ts
+++ b/src/controller/v2/locals/locals.controller.ts
@@ -1,0 +1,22 @@
+// locals.controller.ts
+import { clearProfileCacheService, clearProfileCookiesService } from '@/service/v2/locals/locals.service';
+import type { SubClassConfig } from '@/types';
+
+function localsController(config: SubClassConfig) {
+  function clearProfileCache(profileId: string) {
+    const data = clearProfileCacheService(config, profileId);
+    return data;
+  }
+
+  function clearProfileCookies(profileId: string) {
+    const data = clearProfileCookiesService(config, profileId);
+    return data;
+  }
+
+  return {
+    clearProfileCache,
+    clearProfileCookies,
+  };
+}
+
+export default localsController;

--- a/src/controller/v2/profiles/profiles.controller.ts
+++ b/src/controller/v2/profiles/profiles.controller.ts
@@ -1,0 +1,124 @@
+// profiles.controller.ts
+import {
+  updateProfileProxyService,
+  resetProfileProxyService,
+  createProfileTagsService,
+  updateProfileTagsService,
+  clearProfileTagsService,
+  batchUpdateProxyService,
+  batchResetProfileProxyService,
+  batchCreateProfileTagsService,
+  batchUpdateProfileTagsService,
+  batchClearProfileTagsService,
+  createProfileService,
+  deleteProfileService,
+  deleteProfilesService,
+  getProfilesService,
+  getProfileTagsService,
+} from '@/service/v2/profiles/profiles.service';
+
+import type {
+  BatchUpdateProxyData,
+  BatchUpdateProfilesTagParam,
+  CreateProfileParam,
+  ProfileParams,
+  SubClassConfig,
+  TagsItem,
+} from '@/types';
+
+function profilesController(config: SubClassConfig) {
+  async function updateProfileProxy(profileId: string, param: BatchUpdateProxyData['proxyConfig']) {
+    const data = await updateProfileProxyService(config, profileId, param);
+    return data;
+  }
+
+  async function resetProfileProxy(profileId: string) {
+    const data = await resetProfileProxyService(config, profileId);
+    return data;
+  }
+
+  async function createProfileTags(profileId: string, param: TagsItem[]) {
+    const data = await createProfileTagsService(config, profileId, param);
+    return data;
+  }
+
+  async function updateProfileTags(profileId: string, param: TagsItem[]) {
+    const data = await updateProfileTagsService(config, profileId, param);
+    return data;
+  }
+
+  async function clearProfileTags(profileId: string) {
+    const data = await clearProfileTagsService(config, profileId);
+    return data;
+  }
+
+  async function batchUpdateProxy(param: BatchUpdateProxyData) {
+    const data = await batchUpdateProxyService(config, param);
+    return data;
+  }
+
+  async function batchResetProfileProxy(profileIds: string[]) {
+    const data = await batchResetProfileProxyService(config, profileIds);
+    return data;
+  }
+
+  async function batchCreateProfileTags(param: BatchUpdateProfilesTagParam) {
+    const data = await batchCreateProfileTagsService(config, param);
+    return data;
+  }
+
+  async function batchUpdateProfileTags(param: BatchUpdateProfilesTagParam) {
+    const data = await batchUpdateProfileTagsService(config, param);
+    return data;
+  }
+
+  async function batchClearProfileTags(profileIds: string[]) {
+    const data = await batchClearProfileTagsService(config, profileIds);
+    return data;
+  }
+
+  async function createProfile(param: CreateProfileParam) {
+    const data = await createProfileService(config, param);
+    return data;
+  }
+
+  async function deleteProfile(profileId: string) {
+    const data = await deleteProfileService(config, profileId);
+    return data;
+  }
+
+  async function deleteProfiles(profileIds: string[]) {
+    const data = await deleteProfilesService(config, profileIds);
+    return data;
+  }
+
+  async function getProfiles(param?: ProfileParams) {
+    const data = await getProfilesService(config, param);
+    return data;
+  }
+
+  async function getProfileTags() {
+    const data = await getProfileTagsService(config);
+    return data;
+  }
+
+  return {
+    updateProfileProxy,
+    resetProfileProxy,
+    createProfileTags,
+    updateProfileTags,
+    clearProfileTags,
+    batchUpdateProxy,
+    batchResetProfileProxy,
+    batchCreateProfileTags,
+    batchUpdateProfileTags,
+    batchClearProfileTags,
+    createProfile,
+    deleteProfile,
+    deleteProfiles,
+    getProfiles,
+    getProfileTags,
+  };
+}
+
+export default profilesController;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,16 @@ import browserManager from './controller/browserManager/browserManager.controlle
 import profileManager from './controller/profileManager/profileManager.controller.ts';
 import devtoolManager from './controller/devtoolManager/devtoolManager.controller.ts';
 
+import browsersController from './controller/v2/browsers/browsers.controller.ts';
+import profilesController from './controller/v2/profiles/profiles.controller.ts';
+import cdpEndpointsController from './controller/v2/cdpEndpoints/cdpEndpoints.controller.ts';
+import localsController from './controller/v2/locals/locals.controller.ts';
+
 import Browserless from './browserless/index.ts';
 
 import type { NstBrowserOption } from './types.ts';
 
+/** A more standardized `NstBrowserV2` is recommended. */
 class NstBrowser {
   static instance: null | NstBrowser = null;
 
@@ -73,9 +79,65 @@ class NstBrowser {
   }
 }
 
-export type NstBrowserTypes = typeof NstBrowser;
+class NstBrowserV2 {
+  static instance: null | NstBrowserV2 = null;
 
-export {
-  NstBrowser,
-  Browserless
-};
+  protected apiKey: string = '';
+  protected timeout: number = 0;
+  protected apiAddress: string = 'http://localhost:8848/api/v2';
+
+  constructor(key: string, options?: NstBrowserOption) {
+    if (NstBrowserV2.instance) {
+      return NstBrowserV2.instance;
+    }
+
+    if (!key) {
+      throw new Error('NST ERROR: please input a correct key!');
+    }
+
+    this.apiKey = key;
+    this.timeout = options?.timeout ?? 0;
+    if (options?.apiAddress) {
+      this.apiAddress = options.apiAddress;
+    }
+
+    NstBrowserV2.instance = this;
+  }
+
+  browsers() {
+    return browsersController({
+      apiKey: this.apiKey,
+      timeout: this.timeout,
+      baseUrl: this.apiAddress,
+    });
+  }
+
+  profiles() {
+    return profilesController({
+      apiKey: this.apiKey,
+      timeout: this.timeout,
+      baseUrl: this.apiAddress,
+    });
+  }
+
+  cdpEndpoints() {
+    return cdpEndpointsController({
+      apiKey: this.apiKey,
+      timeout: this.timeout,
+      baseUrl: this.apiAddress,
+    });
+  }
+
+  locals() {
+    return localsController({
+      apiKey: this.apiKey,
+      timeout: this.timeout,
+      baseUrl: this.apiAddress,
+    });
+  }
+}
+
+export type NstBrowserTypes = typeof NstBrowser;
+export type NstBrowserV2Types = typeof NstBrowserV2;
+
+export { NstBrowser, NstBrowserV2, Browserless };

--- a/src/service/v2/browsers/browsers.service.ts
+++ b/src/service/v2/browsers/browsers.service.ts
@@ -1,0 +1,142 @@
+import request from '@/api/http';
+import {
+  BrowserRemoteDebuggerData,
+  StartOnceBrowserParam,
+  NstResponse,
+  SubClassConfig,
+  BrowserPagesData,
+  BrowserStatus,
+  RunningBrowserInfo,
+} from '@/types';
+
+export async function startBrowserService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/browsers/${profileId}`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'post',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function startBrowsersService(
+  config: SubClassConfig,
+  profileIds: string[],
+) {
+  const url = `${config.baseUrl}/browsers`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'post',
+    data: profileIds,
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function startOnceBrowserService(
+  config: SubClassConfig,
+  data: StartOnceBrowserParam,
+) {
+  const url = `${config.baseUrl}/browsers/once`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'post',
+    data,
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function stopBrowserService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/browsers/${profileId}`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function stopBrowsersService(
+  config: SubClassConfig,
+  profileIds: string[],
+) {
+  const url = `${config.baseUrl}/browsers`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    data: profileIds,
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function getBrowsersService(
+  config: SubClassConfig,
+  status?: BrowserStatus,
+) {
+  const url = `${config.baseUrl}/browsers`;
+  const res = await request<NstResponse<RunningBrowserInfo[]>>({
+    url,
+    method: 'get',
+    params: status ? { status } : undefined,
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function getBrowserPagesService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/browsers/${profileId}/pages`;
+  const res = await request<NstResponse<BrowserPagesData[]>>({
+    url,
+    method: 'get',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function getBrowserDebuggerService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/browsers/${profileId}/debugger`;
+  const res = await request<NstResponse<BrowserRemoteDebuggerData>>({
+    url,
+    method: 'get',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}

--- a/src/service/v2/cdpEndpoints/cdpEndpoints.service.ts
+++ b/src/service/v2/cdpEndpoints/cdpEndpoints.service.ts
@@ -1,0 +1,47 @@
+import request from '@/api/http';
+import {
+  BrowserRemoteDebuggerData,
+  ConnectBrowserParam,
+  NstResponse,
+  StartOnceBrowserParam,
+  SubClassConfig,
+} from '@/types';
+
+export async function connectBrowserService(
+  config: SubClassConfig,
+  profileId: string,
+  param: ConnectBrowserParam,
+) {
+  const url = `${config.baseUrl}/connect/${profileId}`;
+  const res = await request<NstResponse<BrowserRemoteDebuggerData>>({
+    url,
+    method: 'get',
+    params: {
+      config: param,
+    },
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function connectOnceBrowserService(
+  config: SubClassConfig,
+  param: StartOnceBrowserParam,
+) {
+  const url = `${config.baseUrl}/connect`;
+  const res = await request<NstResponse<BrowserRemoteDebuggerData>>({
+    url,
+    method: 'get',
+    params: {
+      config: param,
+    },
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}

--- a/src/service/v2/locals/locals.service.ts
+++ b/src/service/v2/locals/locals.service.ts
@@ -1,0 +1,34 @@
+import request from '@/api/http';
+import { NstResponse, SubClassConfig } from '@/types';
+
+export async function clearProfileCacheService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/local/profiles/${profileId}`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}
+
+export async function clearProfileCookiesService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/local/profiles/${profileId}/cookies`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: {
+      'x-api-key': config.apiKey,
+    },
+  });
+  return res;
+}

--- a/src/service/v2/profiles/profiles.service.ts
+++ b/src/service/v2/profiles/profiles.service.ts
@@ -1,0 +1,233 @@
+import request from '@/api/http';
+import {
+  BatchUpdateProfilesTagParam,
+  BatchUpdateProxyData,
+  CreateProfileParam,
+  CreateProfileResponse,
+  NstResponse,
+  ProfileListResponse,
+  ProfileParams,
+  SubClassConfig,
+  TagsItem,
+} from '@/types';
+
+export async function updateProfileProxyService(
+  config: SubClassConfig,
+  profileId: string,
+  data: BatchUpdateProxyData['proxyConfig'],
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}/proxy`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function resetProfileProxyService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}/proxy`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function createProfileTagsService(
+  config: SubClassConfig,
+  profileId: string,
+  data: TagsItem[],
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}/tags`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'post',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function updateProfileTagsService(
+  config: SubClassConfig,
+  profileId: string,
+  data: TagsItem[],
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}/tags`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function clearProfileTagsService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}/tags`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchUpdateProxyService(
+  config: SubClassConfig,
+  data: BatchUpdateProxyData,
+) {
+  const url = `${config.baseUrl}/profiles/proxy/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchResetProfileProxyService(
+  config: SubClassConfig,
+  profileIds: string[],
+) {
+  const url = `${config.baseUrl}/profiles/proxy/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    data: profileIds,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchCreateProfileTagsService(
+  config: SubClassConfig,
+  data: BatchUpdateProfilesTagParam,
+) {
+  const url = `${config.baseUrl}/profiles/tags/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'post',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchUpdateProfileTagsService(
+  config: SubClassConfig,
+  data: BatchUpdateProfilesTagParam,
+) {
+  const url = `${config.baseUrl}/profiles/tags/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchClearProfileTagsService(
+  config: SubClassConfig,
+  profileIds: string[],
+) {
+  const url = `${config.baseUrl}/profiles/tags/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    data: profileIds,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function createProfileService(
+  config: SubClassConfig,
+  data: CreateProfileParam,
+) {
+  const url = `${config.baseUrl}/profiles`;
+  const res = await request<NstResponse<CreateProfileResponse>>({
+    url,
+    method: 'post',
+    data,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function deleteProfileService(
+  config: SubClassConfig,
+  profileId: string,
+) {
+  const url = `${config.baseUrl}/profiles/${profileId}`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function deleteProfilesService(
+  config: SubClassConfig,
+  profileIds: string[],
+) {
+  const url = `${config.baseUrl}/profiles`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'delete',
+    data: profileIds,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function getProfilesService(
+  config: SubClassConfig,
+  params?: ProfileParams,
+) {
+  const url = `${config.baseUrl}/profiles`;
+  const res = await request<NstResponse<ProfileListResponse>>({
+    url,
+    method: 'get',
+    params,
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function getProfileTagsService(config: SubClassConfig) {
+  const url = `${config.baseUrl}/profiles/tags`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'get',
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export type KernelEnum = 'chromium';
 
 export type PlatformEnum = 'linux' | 'mac' | 'windows';
 
+export type BrowserStatus = 'starting' | 'running' | 'stopping';
+
 export type KernelInfo = {
   name: string;
   kernelType: KernelType;
@@ -116,6 +118,35 @@ export interface CreateProfileParam {
   proxy?: string;
   proxyGroupName?: string;
   startupUrls?: string[];
+}
+
+export interface ConnectBrowserParam {
+  autoClose?: boolean;
+  timedCloseSec?: number;
+  headless?: boolean;
+  incognito?: boolean;
+  skipProxyChecking?: boolean;
+  remoteDebuggingPort?: string;
+  args?: Record<string, string>;
+  proxy?: string;
+  startupUrls?: string[];
+  clearCacheOnClose: boolean;
+}
+
+export interface StartOnceBrowserParam
+  extends CreateProfileParam,
+    ConnectBrowserParam {
+  fingerprintRandomness?: boolean;
+}
+
+export interface BrowserPagesData {
+  description: string;
+  devtoolsFrontendUrl: string;
+  id: string;
+  title: string;
+  type: string;
+  url: string;
+  webSocketDebuggerUrl: string;
 }
 
 export interface CreateProfileResponse {


### PR DESCRIPTION
## Support for API v2

### Key Changes:
- Implemented NstBrowserV2 client with complete v2 API support
- Added comprehensive examples for all API functionalities
- Improved error handling and type definitions
- New import path: import { NstBrowserV2 } from 'nstbrowser-sdk-node'

Documentation:
- Added detailed README for v2 API
- Added Puppeteer integration guide