### PR TITLE
feat: add profile group APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Available examples are organized by service:
 - `profiles/resetProfileProxy.js`: Reset proxy configuration for a specific profile
 - `profiles/updateProfileProxy.js`: Update proxy configuration for a specific profile
 - `profiles/updateProfileTags.js`: Update tags for a specific profile
+- `profiles/getAllProfileGroups.js`: Get all profile groups
+- `profiles/changeProfileGroup.js`: Change a profile group
+- `profiles/batchChangeProfileGroup.js`: Batch changes to profile groups
 
 ### Local Data Examples
 - `locals/clearProfileCache.js`: Clear browser cache for a specific profile

--- a/examples/v2/profiles/batchChangeProfileGroup.js
+++ b/examples/v2/profiles/batchChangeProfileGroup.js
@@ -1,0 +1,28 @@
+/**
+ * Example demonstrating how to move multiple profiles to a different group in batch.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profiles and target group for batch update
+const batchGroupData = {
+  profileIds: ['profile_id_1', 'profile_id_2', 'profile_id_3'],
+  groupId: 'target_group_id'
+};
+
+async function batchChangeProfileGroup() {
+  try {
+    const response = await client.profiles().batchChangeProfileGroup(batchGroupData);
+    console.log(`${batchGroupData.profileIds.length} profiles moved to group ${batchGroupData.groupId} successfully`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to batch change profile groups:', error);
+  }
+}
+
+// Execute the example
+batchChangeProfileGroup();

--- a/examples/v2/profiles/changeProfileGroup.js
+++ b/examples/v2/profiles/changeProfileGroup.js
@@ -1,0 +1,26 @@
+/**
+ * Example demonstrating how to move a profile to a different group.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Define the profile and target group
+const profileId = 'your_profile_id';
+const groupId = 'target_group_id';
+
+async function changeProfileGroup() {
+  try {
+    const response = await client.profiles().changeProfileGroup(profileId, groupId);
+    console.log(`Profile ${profileId} moved to group ${groupId} successfully`);
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to change profile group:', error);
+  }
+}
+
+// Execute the example
+changeProfileGroup();

--- a/examples/v2/profiles/getAllProfileGroups.js
+++ b/examples/v2/profiles/getAllProfileGroups.js
@@ -1,0 +1,26 @@
+/**
+ * Example demonstrating how to get all profile groups with optional filtering.
+ */
+
+import { NstBrowserV2 } from 'nstbrowser-sdk-node';
+
+// Initialize the client with your API key
+const apiKey = process.env.NSTBROWSER_API_KEY || 'your_api_key';
+const client = new NstBrowserV2(apiKey);
+
+// Optional group name for filtering
+const groupName = 'work';
+
+async function getAllProfileGroups() {
+  try {
+    // Get all groups or filter by name if provided
+    const response = await client.profiles().getAllProfileGroups(groupName);
+    console.log('Profile groups retrieved successfully');
+    console.log('Response:', response);
+  } catch (error) {
+    console.error('Failed to get profile groups:', error);
+  }
+}
+
+// Execute the example
+getAllProfileGroups();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nstbrowser-sdk-node",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "nst browser node sdk",
   "main": "dist/main.js",
   "exports": {

--- a/src/controller/v2/profiles/profiles.controller.ts
+++ b/src/controller/v2/profiles/profiles.controller.ts
@@ -15,6 +15,9 @@ import {
   deleteProfilesService,
   getProfilesService,
   getProfileTagsService,
+  getAllProfileGroupsService,
+  batchChangeProfileGroupService,
+  changeProfileGroupService,
 } from '@/service/v2/profiles/profiles.service';
 
 import type {
@@ -102,6 +105,22 @@ function profilesController(config: SubClassConfig) {
     return data;
   }
 
+  async function getAllProfileGroups(groupName?: string) {
+    const data = await getAllProfileGroupsService(config,groupName);
+    return data;
+  }
+
+  async function changeProfileGroup(profileId: string, groupId: string) {
+    const data = await changeProfileGroupService(config, profileId, groupId);
+    return data;
+  }
+
+  async function batchChangeProfileGroup(param: { profileIds: string[], groupId: string }) {
+    const data = await batchChangeProfileGroupService(config, param);
+    return data;
+  }
+
+
   return {
     updateProfileProxy,
     resetProfileProxy,
@@ -118,6 +137,9 @@ function profilesController(config: SubClassConfig) {
     deleteProfiles,
     getProfiles,
     getProfileTags,
+    getAllProfileGroups,
+    changeProfileGroup,
+    batchChangeProfileGroup
   };
 }
 

--- a/src/service/v2/profiles/profiles.service.ts
+++ b/src/service/v2/profiles/profiles.service.ts
@@ -231,3 +231,39 @@ export async function getProfileTagsService(config: SubClassConfig) {
   });
   return res;
 }
+
+export async function getAllProfileGroupsService(config: SubClassConfig, groupName?: string) {
+  const url = `${config.baseUrl}/profiles/groups`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'get',
+    params: { groupName },
+    timeout: config.timeout,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function changeProfileGroupService(config: SubClassConfig, profileId: string, groupId: string) {
+  const url = `${config.baseUrl}/profiles/${profileId}/group`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    timeout: config.timeout,
+    data: { groupId },
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}
+
+export async function batchChangeProfileGroupService(config: SubClassConfig, data: { profileIds: string[], groupId: string }) {
+  const url = `${config.baseUrl}/profiles/group/batch`;
+  const res = await request<NstResponse<any>>({
+    url,
+    method: 'put',
+    timeout: config.timeout,
+    data,
+    headers: { 'x-api-key': config.apiKey },
+  });
+  return res;
+}


### PR DESCRIPTION
### adds new profile group management APIs and examples

* `profiles/getAllProfileGroups`: Get all profile groups
* `profiles/changeProfileGroup`: Change group for a single profile
* `profiles/batchChangeProfileGroup`: Change group for multiple profiles in batch
